### PR TITLE
Category view and tests 

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_URL=https://bro-strapi.herokuapp.com

--- a/lib/blocs/category/category_bloc.dart
+++ b/lib/blocs/category/category_bloc.dart
@@ -1,0 +1,42 @@
+import 'dart:developer';
+
+import 'package:bro/blocs/category/category_bucket.dart';
+import 'package:bro/data/category_repository.dart';
+import 'package:bro/models/category.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:meta/meta.dart';
+
+class CategoryBloc extends Bloc<CategoryEvent, CategoryState> {
+  CategoryRepository repository;
+
+  CategoryBloc({@required this.repository})
+      : assert(repository != null),
+        super(Loading());
+
+  @override
+  Stream<CategoryState> mapEventToState(CategoryEvent event) async* {
+    if (event is CategoriesRequested) {
+      try {
+        final result = await repository.getCategories();
+        final categories = result.data['categories'] as List<dynamic>;
+
+        final listOfCategories = categories
+            .map(
+              (dynamic e) => Category(
+                name: e['name'],
+                cover_photo: env['API_URL'] + e['cover_photo']['url'],
+              ),
+            )
+            .toList();
+
+        yield Success(categories: listOfCategories);
+      } catch (e, stackTrace) {
+        log(e.toString());
+        log(stackTrace.toString());
+
+        yield Failed();
+      }
+    }
+  }
+}

--- a/lib/blocs/category/category_bucket.dart
+++ b/lib/blocs/category/category_bucket.dart
@@ -1,0 +1,3 @@
+export 'category_bloc.dart';
+export 'category_event.dart';
+export 'category_state.dart';

--- a/lib/blocs/category/category_event.dart
+++ b/lib/blocs/category/category_event.dart
@@ -1,0 +1,10 @@
+import 'package:equatable/equatable.dart';
+
+abstract class CategoryEvent extends Equatable {
+  CategoryEvent();
+
+  @override
+  List get props => [];
+}
+
+class CategoriesRequested extends CategoryEvent {}

--- a/lib/blocs/category/category_state.dart
+++ b/lib/blocs/category/category_state.dart
@@ -1,0 +1,37 @@
+import 'package:bro/models/category.dart';
+import 'package:equatable/equatable.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:meta/meta.dart';
+
+abstract class CategoryState extends Equatable {
+  CategoryState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class Loading extends CategoryState {}
+
+class Success extends CategoryState {
+  final List<Category> categories;
+
+  Success({@required this.categories}) : assert(categories != null);
+
+  @override
+  List<Object> get props => [categories];
+
+  @override
+  String toString() => 'Success { categories: $categories }';
+}
+
+class Failed extends CategoryState {
+  /*final List<dynamic> errors;
+
+  Failed({@required this.errors}) : assert(errors != null);
+
+  @override
+  List<dynamic> get props => errors;
+
+  @override
+  String toString() => 'Failed( errors: $errors )';*/
+}

--- a/lib/blocs/category/category_state.dart
+++ b/lib/blocs/category/category_state.dart
@@ -1,6 +1,5 @@
 import 'package:bro/models/category.dart';
 import 'package:equatable/equatable.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:meta/meta.dart';
 
 abstract class CategoryState extends Equatable {
@@ -24,14 +23,4 @@ class Success extends CategoryState {
   String toString() => 'Success { categories: $categories }';
 }
 
-class Failed extends CategoryState {
-  /*final List<dynamic> errors;
-
-  Failed({@required this.errors}) : assert(errors != null);
-
-  @override
-  List<dynamic> get props => errors;
-
-  @override
-  String toString() => 'Failed( errors: $errors )';*/
-}
+class Failed extends CategoryState {}

--- a/lib/data/category_repository.dart
+++ b/lib/data/category_repository.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+import 'package:bro/data/queries/category_queries.dart';
+import 'package:gql/language.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:meta/meta.dart';
+
+class CategoryRepository {
+  final GraphQLClient client;
+
+  CategoryRepository({@required this.client}) : assert(client != null);
+
+  // Course type should be made in a models/ directory
+  Future<QueryResult> getCategories() async {
+    final _options = WatchQueryOptions(
+      document: parseString(getCategoryQuery),
+      fetchResults: true,
+    );
+
+    return await client.query(_options);
+  }
+}

--- a/lib/data/queries/category_queries.dart
+++ b/lib/data/queries/category_queries.dart
@@ -1,0 +1,8 @@
+final String getCategoryQuery = r'''
+query {
+  categories {
+    name,
+    cover_photo {url}
+  }
+}
+''';

--- a/lib/models/category.dart
+++ b/lib/models/category.dart
@@ -1,0 +1,9 @@
+class Category {
+  Category({
+    this.name,
+    this.cover_photo,
+  });
+
+  final String name;
+  final String cover_photo;
+}

--- a/lib/views/category_view/category_view.dart
+++ b/lib/views/category_view/category_view.dart
@@ -86,9 +86,9 @@ class _CategoryViewState extends State<CategoryView> {
                 children: <Widget>[
                   GestureDetector(
                     onHorizontalDragEnd: (DragEndDetails details) {
-                      if (details.velocity.pixelsPerSecond.dx < 0) {
+                      if (details.velocity.pixelsPerSecond.dx > 0) {
                         _prev();
-                      } else if (details.velocity.pixelsPerSecond.dx > 0) {
+                      } else if (details.velocity.pixelsPerSecond.dx < 0) {
                         _next();
                       }
                     },

--- a/lib/views/category_view/category_view.dart
+++ b/lib/views/category_view/category_view.dart
@@ -1,0 +1,249 @@
+import 'dart:developer';
+
+import 'package:bro/blocs/category/category_bucket.dart';
+import 'package:bro/models/category.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+class CategoryView extends StatefulWidget {
+  @override
+  _CategoryViewState createState() => _CategoryViewState();
+}
+
+class _CategoryViewState extends State<CategoryView> {
+  CategoryBloc _categoryBloc;
+  List<Category> categories = [];
+  int currentIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _categoryBloc = BlocProvider.of<CategoryBloc>(context);
+    _categoryBloc.add(CategoriesRequested());
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  void _next() {
+    setState(() {
+      if (currentIndex < categories.length - 1) {
+        currentIndex++;
+      } else {
+        currentIndex = currentIndex;
+      }
+    });
+  }
+
+  void _prev() {
+    setState(() {
+      if (currentIndex > 0) {
+        currentIndex--;
+      } else {
+        currentIndex = 0;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<CategoryBloc, CategoryState>(
+      // ignore: missing_return
+      builder: (context, state) {
+        if (state is Loading) {
+          return Scaffold(
+            body: Center(
+              child: CircularProgressIndicator(),
+            ),
+          );
+        }
+
+        if (state is Failed) {
+          return Scaffold(
+            body: Center(
+              child: Text('ERROR'),
+            ),
+          );
+        }
+
+        if (state is Success) {
+          categories = state.categories;
+
+          if (categories.isEmpty) {
+            return Scaffold(
+              body: Center(
+                child: Text('Ingen tilgjengelige kategorier'),
+              ),
+            );
+          }
+
+          return Scaffold(
+            body: Container(
+              child: Column(
+                children: <Widget>[
+                  GestureDetector(
+                    onHorizontalDragEnd: (DragEndDetails details) {
+                      if (details.velocity.pixelsPerSecond.dx < 0) {
+                        _prev();
+                      } else if (details.velocity.pixelsPerSecond.dx > 0) {
+                        _next();
+                      }
+                    },
+                    child: Container(
+                      width: double.infinity,
+                      height: 500,
+                      decoration: BoxDecoration(
+                        image: DecorationImage(
+                          image: NetworkImage(
+                              categories[currentIndex].cover_photo),
+                          onError: (exception, stackTrace) {
+                            return Text('Could not load image');
+                          },
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.bottomRight,
+                            colors: [
+                              Theme.of(context)
+                                  .scaffoldBackgroundColor
+                                  .withOpacity(1),
+                              Theme.of(context)
+                                  .scaffoldBackgroundColor
+                                  .withOpacity(0),
+                            ],
+                          ),
+                        ),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: <Widget>[
+                            Container(
+                              width: 90,
+                              margin: EdgeInsets.only(bottom: 50),
+                              child: Row(
+                                children: _buildIndicator(),
+                              ),
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Container(
+                      width: double.infinity,
+                      padding: EdgeInsets.all(32),
+                      child: Column(
+                        children: <Widget>[
+                          Row(
+                            children: <Widget>[
+                              GestureDetector(
+                                onTap: () {
+                                  _prev();
+                                },
+                                child: FaIcon(
+                                  FontAwesomeIcons.chevronLeft,
+                                  color: Theme.of(context).primaryColor,
+                                  size: 24,
+                                ),
+                              ),
+                              Expanded(
+                                child: Center(
+                                  child: Text(
+                                    categories[currentIndex].name,
+                                    style:
+                                        Theme.of(context).textTheme.headline4,
+                                  ),
+                                ),
+                              ),
+                              GestureDetector(
+                                onTap: () {
+                                  _next();
+                                },
+                                child: FaIcon(
+                                  FontAwesomeIcons.chevronRight,
+                                  color: Theme.of(context).primaryColor,
+                                  size: 24,
+                                ),
+                              ),
+                            ],
+                          ),
+                          Expanded(
+                            child: Align(
+                              child: Text(
+                                'Her kommer beskrivelsen',
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: Align(
+                              child: GestureDetector(
+                                onTap: () {
+                                  log("ROUTING HER");
+                                },
+                                child: Container(
+                                  height: 50,
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context).primaryColor,
+                                    borderRadius: BorderRadius.circular(5),
+                                  ),
+                                  child: Center(
+                                    child: Text(
+                                      'SE OVERSIKT',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .button
+                                          .copyWith(
+                                              color: Theme.of(context)
+                                                  .scaffoldBackgroundColor),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  Widget _indicator(bool isActive) {
+    return Expanded(
+      child: Container(
+        height: 4,
+        margin: EdgeInsets.only(right: 5),
+        decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(50),
+            color: isActive
+                ? Theme.of(context).primaryColor
+                : Theme.of(context).scaffoldBackgroundColor),
+      ),
+    );
+  }
+
+  List<Widget> _buildIndicator() {
+    var indicators = <Widget>[];
+    for (var i = 0; i < categories.length; i++) {
+      if (currentIndex == i) {
+        indicators.add(_indicator(true));
+      } else {
+        indicators.add(_indicator(false));
+      }
+    }
+
+    return indicators;
+  }
+}

--- a/lib/views/category_view/category_view.dart
+++ b/lib/views/category_view/category_view.dart
@@ -184,7 +184,7 @@ class _CategoryViewState extends State<CategoryView> {
                             child: Align(
                               child: GestureDetector(
                                 onTap: () {
-                                  log("ROUTING HER");
+                                  log('ROUTING HER');
                                 },
                                 child: Container(
                                   height: 50,

--- a/lib/views/main.dart
+++ b/lib/views/main.dart
@@ -1,14 +1,21 @@
+import 'package:bro/blocs/category/category_bucket.dart';
 import 'package:bro/blocs/course_list/course_list_bucket.dart';
 import 'package:bro/blocs/simple_bloc_observer.dart';
+import 'package:bro/data/category_repository.dart';
 import 'package:bro/data/course_repository.dart';
 import 'package:bro/views/course/course_list_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart' as DotEnv;
 
-void main() {
+import 'category_view/category_view.dart';
+
+Future main() async {
   Bloc.observer = SimpleBlocObserver();
-
+  await DotEnv.load();
   runApp(App());
 }
 
@@ -33,7 +40,11 @@ class App extends StatelessWidget {
           brightness: Brightness.light,
           textTheme: Typography.material2018()
               .black
-              .copyWith(headline6: TextStyle(color: Colors.teal))
+              .copyWith(
+                  headline6: GoogleFonts.notoSans(
+                color: Colors.teal,
+                fontWeight: FontWeight.bold,
+              ))
               .merge(Typography.englishLike2018),
           iconTheme: const IconThemeData(color: Colors.teal),
           actionsIconTheme: const IconThemeData(color: Colors.teal),
@@ -43,32 +54,38 @@ class App extends StatelessWidget {
         cardTheme: CardTheme(elevation: 5.0),
         iconTheme: IconThemeData(size: 18.0, color: Colors.white),
         textTheme: TextTheme(
-          headline1: TextStyle(
+          headline1: GoogleFonts.notoSans(
             fontSize: 72.0,
             fontWeight: FontWeight.bold,
             color: Colors.teal,
           ),
-          headline6: TextStyle(
+          headline4: GoogleFonts.notoSans(color: Colors.teal),
+          headline6: GoogleFonts.notoSans(
             fontSize: 20.0,
             fontWeight: FontWeight.w500,
             color: Colors.teal,
           ),
-          subtitle1: TextStyle(
+          subtitle1: GoogleFonts.notoSans(
             fontSize: 16.0,
             fontWeight: FontWeight.normal,
             letterSpacing: 0.15,
             color: Colors.black,
           ),
-          subtitle2: TextStyle(
+          subtitle2: GoogleFonts.notoSans(
             fontSize: 14.0,
             fontWeight: FontWeight.w500,
             letterSpacing: 0.10,
             color: Colors.black,
           ),
-          caption: TextStyle(
+          caption: GoogleFonts.notoSans(
             fontSize: 12.0,
             fontWeight: FontWeight.normal,
             letterSpacing: 0.40,
+          ),
+          button: GoogleFonts.notoSans(
+            fontSize: 14.0,
+            fontWeight: FontWeight.bold,
+            letterSpacing: 0.125,
           ),
         ),
       ),
@@ -81,13 +98,21 @@ class App extends StatelessWidget {
               ),
               child: CourseListView(),
             ),
+        'category-view': (_) => BlocProvider(
+              create: (context) => CategoryBloc(
+                repository: CategoryRepository(
+                  client: _client(),
+                ),
+              ),
+              child: CategoryView(),
+            ),
       },
       home: Home(),
     );
   }
 
   GraphQLClient _client() {
-    final _link = HttpLink('https://bro-strapi.herokuapp.com/graphql');
+    final _link = HttpLink(env['API_URL'] + '/graphql');
 
     return GraphQLClient(
       cache: GraphQLCache(store: InMemoryStore()),
@@ -108,6 +133,10 @@ class Home extends StatelessWidget {
           ListTile(
             title: Text('CourseListView'),
             onTap: () => Navigator.of(context).pushNamed('course-view'),
+          ),
+          ListTile(
+            title: Text('CategoryView'),
+            onTap: () => Navigator.of(context).pushNamed('category-view'),
           ),
         ],
       ),

--- a/lib/views/main.dart
+++ b/lib/views/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+// ignore: library_prefixes
 import 'package:flutter_dotenv/flutter_dotenv.dart' as DotEnv;
 
 import 'category_view/category_view.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,14 +77,14 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.0-nullsafety.0"
+    version: "8.0.4"
   cached_network_image:
     dependency: "direct main"
     description:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   characters:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   clock:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.0"
+    version: "3.7.0"
   collection:
     dependency: transitive
     description:
@@ -224,14 +224,14 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.0"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.1.0"
   fixnum:
     dependency: transitive
     description:
@@ -264,7 +264,14 @@ packages:
       name: flutter_cache_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -281,14 +288,21 @@ packages:
       name: font_awesome_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.11.0"
+    version: "8.12.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   gql:
     dependency: "direct main"
     description:
@@ -394,13 +408,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.19"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
   io:
     dependency: transitive
     description:
@@ -457,20 +464,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
   node_preamble:
     dependency: transitive
     description:
@@ -512,7 +505,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.27"
+    version: "1.6.28"
   path_provider_linux:
     dependency: transitive
     description:
@@ -540,14 +533,14 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+3"
+    version: "0.0.5"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:
@@ -582,7 +575,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.13"
+    version: "4.1.1"
   provider:
     dependency: transitive
     description:
@@ -596,7 +589,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.0.0"
   rxdart:
     dependency: transitive
     description:
@@ -671,14 +664,14 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2+3"
+    version: "2.0.0+3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3+1"
+    version: "2.0.0+2"
   stack_trace:
     dependency: transitive
     description:
@@ -706,7 +699,7 @@ packages:
       name: synchronized
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0+2"
+    version: "3.0.0"
   term_glyph:
     dependency: transitive
     description:
@@ -776,7 +769,7 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -804,7 +797,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.4+1"
+    version: "2.0.4"
   xdg_directories:
     dependency: transitive
     description:
@@ -825,7 +818,7 @@ packages:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.22.2"
+  flutter: ">=1.24.0-10"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
     equatable: ^2.0.0
     meta: ^1.2.2
     dots_indicator: ^2.0.0
+    flutter_dotenv: ^3.1.0
+    google_fonts: ^1.1.2
 
     # The following adds the Cupertino Icons font to your application.
     # Use with the CupertinoIcons class for iOS style icons.
@@ -44,7 +46,7 @@ dev_dependencies:
     pedantic: ^1.9.0
     flutter_test:
         sdk: flutter
-    mockito: ^4.1.4
+    mockito: ^4.0.0
     test:
     bloc_test: ^7.0.0
 
@@ -59,8 +61,8 @@ flutter:
     uses-material-design: true
 
     # To add assets to your application, add an assets section, like this:
-    # assets:
-    #   - images/a_dot_burr.jpeg
+    assets:
+        - .env
     #   - images/a_dot_ham.jpeg
 
     # An image asset can refer to one or more resolution-specific "variants", see

--- a/test/blocs/category_bloc_test.dart
+++ b/test/blocs/category_bloc_test.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:bro/blocs/category/category_bucket.dart';
 import 'package:bro/data/category_repository.dart';
+// ignore: library_prefixes
 import 'package:flutter_dotenv/flutter_dotenv.dart' as DotEnv;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';

--- a/test/blocs/category_bloc_test.dart
+++ b/test/blocs/category_bloc_test.dart
@@ -1,0 +1,54 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:bro/blocs/category/category_bucket.dart';
+import 'package:bro/data/category_repository.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart' as DotEnv;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mock_data/category_mock.dart';
+
+class MockCategoryRepository extends Mock implements CategoryRepository {}
+
+void main() async {
+  // For DotEnv
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await DotEnv.load();
+
+  group('CategoryBloc', () {
+    CategoryRepository categoryRepository;
+    CategoryBloc categoryBloc;
+
+    setUp(() {
+      categoryRepository = MockCategoryRepository();
+      when(categoryRepository.getCategories()).thenAnswer(
+          (_) => Future.value(QueryResult(source: null, data: mockedResult)));
+      categoryBloc = CategoryBloc(repository: categoryRepository);
+    });
+
+    blocTest(
+      'should emit Failed if repository throws',
+      build: () {
+        when(categoryRepository.getCategories()).thenThrow(Exception('Woops'));
+        return categoryBloc;
+      },
+      act: (CategoryBloc bloc) async => bloc.add(CategoriesRequested()),
+      expect: <CategoryState>[Failed()],
+    );
+
+    blocTest(
+      'Initial state is correct',
+      build: () => categoryBloc,
+      expect: <CategoryState>[],
+    );
+
+    blocTest(
+      'should load items in response to a CategoriesRequested event',
+      build: () => categoryBloc,
+      act: (CategoryBloc bloc) async => bloc.add(CategoriesRequested()),
+      expect: [
+        isA<Success>(),
+      ],
+    );
+  });
+}

--- a/test/blocs/category_event_test.dart
+++ b/test/blocs/category_event_test.dart
@@ -1,0 +1,12 @@
+import 'package:bro/blocs/category/category_bucket.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CategoryEvent', () {
+    group('CategoryRequested', () {
+      test('toString returns correct value', () {
+        expect(CategoriesRequested().toString(), 'CategoriesRequested()');
+      });
+    });
+  });
+}

--- a/test/blocs/category_state_test.dart
+++ b/test/blocs/category_state_test.dart
@@ -1,0 +1,31 @@
+import 'package:bro/blocs/category/category_bucket.dart';
+import 'package:bro/models/category.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CategoryState', () {
+    group('CategoryLoading', () {
+      test('toString returns correct value', () {
+        expect(Loading().toString(), 'Loading()');
+      });
+    });
+
+    group('CategorySuccess', () {
+      final category = Category(
+        name: 'Kategori',
+        cover_photo: 'Dette er en kategoribeskrivelse!',
+      );
+
+      test('toString returns correct value', () {
+        expect(Success(categories: [category]).toString(),
+            'Success { categories: [$category] }');
+      });
+    });
+
+    group('CategoryFailed', () {
+      test('toString returns correct value', () {
+        expect(Failed().toString(), 'Failed()');
+      });
+    });
+  });
+}

--- a/test/mock_data/category_mock.dart
+++ b/test/mock_data/category_mock.dart
@@ -1,0 +1,17 @@
+int id = 0;
+String name = 'Kategoritittel';
+String description = 'En litt for kort kategoribeskrivelse';
+String coverPhoto = '/image_url.jpg';
+
+Map<String, dynamic> mockedResult = {
+  'categories': [
+    {
+      'name': 'Helsetjenester',
+      'cover_photo': {'url': '/uploads/pexels_photo_4047186_0f8687c70e.jpeg'}
+    },
+    {
+      'name': 'Økonomi',
+      'cover_photo': {'url': '/uploads/coins_933142c8fe.jpeg'}
+    }
+  ]
+};

--- a/test/views/category_view_test.dart
+++ b/test/views/category_view_test.dart
@@ -1,0 +1,70 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:bro/blocs/category/category_bucket.dart';
+import 'package:bro/blocs/category/category_event.dart';
+import 'package:bro/models/category.dart';
+import 'package:bro/views/category_view/category_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+class MockCategoryView extends MockBloc<CategoryEvent> implements CategoryBloc {
+}
+
+void main() {
+  group('CategoryView', () {
+    CategoryBloc categoryBloc;
+
+    setUp(() {
+      categoryBloc = MockCategoryView();
+    });
+
+    tearDown(() {
+      categoryBloc.close();
+    });
+
+    testWidgets('renders properly without categories',
+        (WidgetTester tester) async {
+      when(categoryBloc.state).thenReturn(
+        Success(
+          categories: [],
+        ),
+      );
+      await tester.pumpWidget(
+        BlocProvider.value(
+          value: categoryBloc,
+          child: MaterialApp(
+            home: Scaffold(
+              body: CategoryView(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Ingen tilgjengelige kategorier'), findsOneWidget);
+    });
+
+    testWidgets('renders properly with categories',
+        (WidgetTester tester) async {
+      when(categoryBloc.state).thenReturn(
+        Success(
+          categories: [
+            Category(name: 'Testkategori', cover_photo: '/image.url.png')
+          ],
+        ),
+      );
+      await tester.pumpWidget(
+        BlocProvider.value(
+          value: categoryBloc,
+          child: MaterialApp(
+            home: Scaffold(
+              body: CategoryView(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Testkategori'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes BL-92

This PR adds: 
- The category main view
- Bloc implementation for categories. 
- Tests for said view and blocs. 
- DotEnv for easier configuration. 

Unresolved questions/issues: 
- Description of categories is still missing, but should just very easy to implement when ready. 
- Routing to article list views. This is also planned for. 
- There is currently no transition animation when "sliding" through the carousel. 